### PR TITLE
Added License file as well as HTML version of it. Added link to MIT l…

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+The MIT License
+
+Copyright 2016 Rafael Corrêa Gomes, https://rafaelstz.github.io/
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSE.html
+++ b/LICENSE.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+
+<html id="home" lang="en">
+
+<head>
+    <title>MIT License</title>
+    <meta charset=utf-8>
+
+    <meta name="robots" content="noindex">
+    <meta name=viewport content="width=device-width, initial-scale=0.70;">
+    
+    <style>
+        @import url(http://fonts.googleapis.com/css?family=Inconsolata);
+        body {
+            max-width: 625px;
+        }
+
+        body,
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6 {
+            font: normal 15px Inconsolata, Consolas, monospace;
+        }
+    </style>
+</head>
+
+<body>
+    <article>
+        <h1>The MIT License (MIT)</h1>
+        <p>Copyright (c) 2016 Rafael Corrêa Gomes, <a href="https://rafaelstz.github.io/">https://rafaelstz.github.io/</a></p>
+
+        <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation
+            files (the "Software"), to deal in the Software without restriction, including without limitation the rights
+            to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+            persons to whom the Software is furnished to do so, subject to the following conditions:</p>
+
+        <p>The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+            the Software.</p>
+
+        <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+            THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+            AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+            TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+            SOFTWARE.</p>
+    </article>
+
+    <body>
+
+</html>

--- a/index.html
+++ b/index.html
@@ -1041,6 +1041,7 @@
                     <div class="col-xs-12">Developed by:<a href="https://github.com/rafaelstz" title="Rafael Corrêa Gomes">Rafael Corrêa Gomes</a>
                     </div>
                     <div class="col-xs-12">&copy;2016 <a href="http://comandosgit.github.io/">Comandosgit.github.io</a></div>
+                    <div class="col-xs-12"><a href="/license.html">License MIT</a></div>
                 </div>
             </div>
         </footer>


### PR DESCRIPTION
Hi Rafael,

I've added two files for MIT license.

1. [LICENSE](https://github.com/dance2die/comandosgit.github.io/blob/master/LICENSE) - Text version of MIT license.
2. [LICENSE.html](https://github.com/dance2die/comandosgit.github.io/blob/master/LICENSE.html) - HTML version, which the link on index.html directs you to.
________
`Index.html` is updated as shown below.

![image](https://user-images.githubusercontent.com/8465237/31525840-219d0c56-af91-11e7-8c68-fa06408eec9a.png)
________
`LICENSE.html` looks as follows.

![image](https://user-images.githubusercontent.com/8465237/31525853-2c08dfda-af91-11e7-9d73-45b1df3af938.png)


