### PR TITLE
Update footer links and copyright year

### DIFF
--- a/index.html
+++ b/index.html
@@ -1048,10 +1048,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             </div>
             <div class="col-xs-offset-2 col-xs-3">
                 <div class="row">
-                    <div class="col-xs-12">Developed by:<a href="https://github.com/rafaelstz" title="Rafael Corrêa Gomes">Rafael Corrêa Gomes</a>
+                    <div class="col-xs-12">Developed by:<a href="https://rafaelcg.com?utm_source=comandosgit" title="Rafael Corrêa Gomes">Rafael Corrêa Gomes</a>
                     </div>
-                    <div class="col-xs-12">&copy;2016 <a href="https://comandosgit.github.io/">Comandosgit.github.io</a></div>
-                    <div class="col-xs-12"><a href="/license.html">License MIT</a></div>
+                    <div class="col-xs-12">&copy;2025 <a href="https://comandosgit.github.io/">Comandosgit.github.io</a></div>
+                    <div class="col-xs-12"><a href="https://github.com/comandosgit/comandosgit.github.io/blob/master/LICENSE">License MIT</a></div>
                 </div>
             </div>
         </footer>


### PR DESCRIPTION
## Summary
- update the footer developer link to point to the new personal site
- refresh the copyright notice to use 2025
- link the MIT license reference to the GitHub-hosted license file

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_6902b08dd46883338508e73b15114ad7